### PR TITLE
Background proper display

### DIFF
--- a/src/DATA/planebg.obj
+++ b/src/DATA/planebg.obj
@@ -1,0 +1,28 @@
+# File produced by AccuTrans 3D
+# Output decimal 4
+
+g acmat_0
+
+v -48.0 -27.2 -60.662338
+v 48.0 -27.2 -60.662338
+v 48.0 27.2 -60.662338
+v -48.0 27.2 -60.662338
+# 4 vertices
+
+vt 0 0
+vt 0 1.0
+vt 1.0 0
+vt 1.0 1.0
+# 4 texture vertices
+
+vn 0 0 1.0
+# 1 vertex normals
+
+s off
+
+usemtl acmat_0
+
+f 2/3/1 3/4/1 1/1/1
+f 4/2/1 1/1/1 3/4/1
+# 2 faces
+

--- a/src/index.lua
+++ b/src/index.lua
@@ -8636,7 +8636,6 @@ local function DrawCover(x, y, text, icon, sel, apptype)
         -- left side view
         zoom = -0.6
         extray = -0.3
-        camX = 1
 
         if smoothScrolling == 1 then
             -- Smooth scrolling is on
@@ -8669,6 +8668,8 @@ local function DrawCover(x, y, text, icon, sel, apptype)
                 extrax = -10
             end
         end
+
+        extrax = extrax - 1 --move to the left
 
     elseif showView == 4 then
         -- scroll around

--- a/src/index.lua
+++ b/src/index.lua
@@ -2029,7 +2029,7 @@ else
     else
         if System.doesFileExist(wallpaper_table_settings[selectedwall].wallpaper_path) then
             imgCustomBack = Graphics.loadImage(wallpaper_table_settings[selectedwall].wallpaper_path)
-            Graphics.setImageFilters(imgCustomBack, FILTER_LINEAR, FILTER_LINEAR)
+            --Graphics.setImageFilters(imgCustomBack, FILTER_LINEAR, FILTER_LINEAR)
             Render.useTexture(modBackground, imgCustomBack)
         end
     end


### PR DESCRIPTION
Hi!

The background was being displayed oddly since HexFlow:
- Bad aspect ratio and zoomed in(due to planebg.obj being the wrong proportions),
- and moving to the left on view 3 (due to the camera being moved).

I tried using drawImage instead, but I didn't manage to make it draw "behind" the rest of the graphics.

So I fixed the planebg.obj values to have the good aspect ratio, and found the Z value by guesswork (…)
I couldn't find an exact Z value for pixel-perfect display, so I removed linear filtering because it would slightly alter the image, and now it's pixel-perfect!
