### PR TITLE
Add resume position setting

### DIFF
--- a/src/index.lua
+++ b/src/index.lua
@@ -27,7 +27,7 @@ System.setCpuSpeed(cpu_speed)
 Sound.init()
 
 local working_dir = "ux0:/app"
-local appversion = "8.1.0"
+local appversion = "8.2.0"
 function System.currentDirectory(dir)
     if dir == nil then
         return working_dir
@@ -3163,6 +3163,7 @@ setTime = 0 -- 24 hour
 local filterGames = 0 -- All
 showMissingCovers = 1 -- On
 local smoothScrolling = 1 -- On
+local setResumePosition = 0 -- Off
 
 set2DViews = 1 -- On
 setChangeViews = 1 -- On
@@ -3232,13 +3233,56 @@ function SaveSettings()
         "\nShow_System_Apps=" .. showSysApps .. " " .. 
         "\nExtract_PSP_backgrounds=" .. setPSPExtractBG .. " " .. 
         "\nShow_cores=" .. setShowCores .. " " .. 
-        "\nScan_cartridges" .. setScanCartridges .. " " .. 
+        "\nScan_cartridges" .. setScanCartridges .. " " ..
+        "\nResume_position=" .. setResumePosition .. " " ..
         "\nStartup_Collection=" .. startCategory_collection -- MUST ALWAYS BE LAST -- the config is split into a table using number values which this setting does not have. Need to add proper ini file reading
 
         file_config:write(settings)
         file_config:close()
 
     else
+    end
+end
+
+function SaveLastPosition()
+    if setResumePosition == 1 then
+        local f = io.open(cur_dir .. "/last_position.dat", "w")
+        if f ~= nil then
+            f:write("Cat=" .. tostring(showCat) .. "\nPos=" .. tostring(p))
+            f:close()
+        end
+    end
+end
+
+function LoadLastPosition()
+    if setResumePosition == 1 and System.doesFileExist(cur_dir .. "/last_position.dat") then
+        local f = System.openFile(cur_dir .. "/last_position.dat", FREAD)
+        local size = System.sizeFile(f)
+        local str = System.readFile(f, size)
+        System.closeFile(f)
+        local savedCat = tonumber(str:match("Cat=(%d+)"))
+        local savedPos = tonumber(str:match("Pos=(%d+)"))
+        if savedCat ~= nil then
+            if savedCat >= 50 then
+                -- Validate the collection still exists
+                local collectionIdx = savedCat - 49
+                if collection_files and collection_files[collectionIdx] then
+                    showCat = savedCat
+                else
+                    showCat = startCategory
+                end
+            elseif savedCat == 49 then
+                -- Search results don't persist across launches
+                showCat = startCategory
+            else
+                showCat = savedCat
+            end
+        end
+        if savedPos ~= nil then
+            p = savedPos
+            master_index = p
+        end
+        check_for_out_of_bounds()
     end
 end
 
@@ -3301,7 +3345,8 @@ if System.doesFileExist(cur_dir .. "/config.dat") then
     local getPSPExtractBG = settingValue[28]; if getPSPExtractBG ~= nil then setPSPExtractBG = getPSPExtractBG end
     local getShowCores = settingValue[29]; if getShowCores ~= nil then setShowCores = getShowCores end
     local getScanCartridges = settingValue[30]; if getScanCartridges ~= nil then setScanCartridges = getScanCartridges end
-    -- settingValue[26] is startup collection 
+    local getResumePosition = settingValue[31]; if getResumePosition ~= nil then setResumePosition = getResumePosition end
+    -- settingValue[31] is startup collection
 
     selectedwall = setBackground
 
@@ -3892,6 +3937,7 @@ local lang_default =
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Show game core menu:",
 ["Global_core_settings"] = "Global core settings",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulator core",
 ["Core_colon"] = "Core:",
@@ -5245,8 +5291,9 @@ function check_game_available_appdb(def_titleid)
 end
 
 function prepare_for_launch()
+    SaveLastPosition()
     FreeMemory()
-    -- Add to recently played 
+    -- Add to recently played
     AddtoRecentlyPlayed()
     update_cached_table_recently_played_pre_launch()
 end
@@ -13937,6 +13984,8 @@ end
 -- Capture function load time before main loop starts (major performance optimization)
 functionTime = Timer.getTime(oneLoopTimer)
 
+LoadLastPosition()
+
 -- Main loop
 while true do
 
@@ -18316,7 +18365,7 @@ while true do
         Graphics.fillRect(60, 900, 82 + (menuY * 47), 129 + (menuY * 47), themeCol)-- selection
 
 
-        menuItems = 7
+        menuItems = 8
 
         -- MENU 19 / #0 Back
         Font.print(fnt22, setting_x, setting_y0, lang_lines.Back_Chevron, white)--Back
@@ -18369,6 +18418,14 @@ while true do
         
         -- MENU 19 / #7 Global core settings
         Font.print(fnt22, setting_x, setting_y7, lang_lines.Global_core_settings, white)--Global core settings
+
+        -- MENU 19 / #8 Resume position
+        Font.print(fnt22, setting_x, setting_y8, lang_lines.Resume_position_colon, white)
+        if setResumePosition == 1 then
+            Font.print(fnt22, setting_x_offset, setting_y8, lang_lines.On, white)
+        else
+            Font.print(fnt22, setting_x_offset, setting_y8, lang_lines.Off, white)
+        end
 
         -- MENU 19 - FUNCTIONS
         status = System.getMessageState()
@@ -18454,8 +18511,15 @@ while true do
                     menuY = 0
                 
                 elseif menuY == 7 then -- #7 Change emulator cores
-                    showMenu = 28 
+                    showMenu = 28
                     menuY = 0
+
+                elseif menuY == 8 then -- #8 Resume position
+                    if setResumePosition == 1 then
+                        setResumePosition = 0
+                    else
+                        setResumePosition = 1
+                    end
                 end
 
                 --Save settings

--- a/src/index.lua
+++ b/src/index.lua
@@ -12856,6 +12856,40 @@ local function DrawCover(x, y, text, icon, sel, apptype, cur_p)
 end
 
 local FileLoad = {}
+
+function PreloadRestoredCovers()
+    if setResumePosition ~= 1 then return end
+    local def = xCatLookup(showCat)
+    local total = #def
+    if total == 0 then return end
+    -- Synchronously load the selected cover and its immediate neighbours so
+    -- they are ready on the first frame with no pop-in.
+    local sync_from = math.max(1, p - 2)
+    local sync_to   = math.min(total, p + 2)
+    for i = sync_from, sync_to do
+        local file = def[i]
+        if file and file.icon_path and FileLoad[file] == nil then
+            file.ricon   = Graphics.loadImage(file.icon_path)
+            FileLoad[file] = true
+        end
+    end
+    -- Async-queue the wider neighbourhood so scrolling away feels smooth.
+    local async_from = math.max(1, p - 5)
+    local async_to   = math.min(total, p + 5)
+    for i = async_from, async_to do
+        local file = def[i]
+        if file and file.icon_path and FileLoad[file] == nil then
+            FileLoad[file] = true
+            Threads.addTask(file, {
+                Type  = "ImageLoad",
+                Path  = file.icon_path,
+                Table = file,
+                Index = "ricon"
+            })
+        end
+    end
+end
+
 flat_cleanup_table = nil
 flat_cleanup_start = nil
 flat_cleanup_end = nil
@@ -13985,6 +14019,7 @@ end
 functionTime = Timer.getTime(oneLoopTimer)
 
 LoadLastPosition()
+PreloadRestoredCovers()
 
 -- Main loop
 while true do
@@ -18357,7 +18392,7 @@ while true do
         Graphics.drawImage(900-(btnMargin * 2)-label1-label2, 510, btnX)
         Font.print(fnt20, 900+28-(btnMargin * 2)-label1-label2, 508, lang_lines.Select, white)--Select
 
-        Graphics.fillRect(60, 900, 34, 460, darkalpha)
+        Graphics.fillRect(60, 900, 34, 515, darkalpha)
 
         Font.print(fnt22, setting_x, setting_yh, lang_lines.Other_Settings, white)--Other Settings
         Graphics.fillRect(60, 900, 78, 81, white)

--- a/src/index.lua
+++ b/src/index.lua
@@ -12862,30 +12862,13 @@ function PreloadRestoredCovers()
     local def = xCatLookup(showCat)
     local total = #def
     if total == 0 then return end
-    -- Synchronously load the selected cover and its immediate neighbours so
-    -- they are ready on the first frame with no pop-in.
-    local sync_from = math.max(1, p - 2)
-    local sync_to   = math.min(total, p + 2)
-    for i = sync_from, sync_to do
+    local from = math.max(1, p - 5)
+    local to   = math.min(total, p + 5)
+    for i = from, to do
         local file = def[i]
         if file and file.icon_path and FileLoad[file] == nil then
-            file.ricon   = Graphics.loadImage(file.icon_path)
+            file.ricon    = Graphics.loadImage(file.icon_path)
             FileLoad[file] = true
-        end
-    end
-    -- Async-queue the wider neighbourhood so scrolling away feels smooth.
-    local async_from = math.max(1, p - 5)
-    local async_to   = math.min(total, p + 5)
-    for i = async_from, async_to do
-        local file = def[i]
-        if file and file.icon_path and FileLoad[file] == nil then
-            FileLoad[file] = true
-            Threads.addTask(file, {
-                Type  = "ImageLoad",
-                Path  = file.icon_path,
-                Table = file,
-                Index = "ricon"
-            })
         end
     end
 end

--- a/src/index.lua
+++ b/src/index.lua
@@ -12862,14 +12862,18 @@ function PreloadRestoredCovers()
     local def = xCatLookup(showCat)
     local total = #def
     if total == 0 then return end
-    local from = math.max(1, p - 5)
-    local to   = math.min(total, p + 5)
-    for i = from, to do
+    local function preload(i)
+        if i < 1 or i > total then return end
         local file = def[i]
         if file and file.icon_path and FileLoad[file] == nil then
             file.ricon    = Graphics.loadImage(file.icon_path)
             FileLoad[file] = true
         end
+    end
+    preload(p)
+    for offset = 1, 5 do
+        preload(p - offset)
+        preload(p + offset)
     end
 end
 
@@ -13468,11 +13472,26 @@ function drawCategory (def)
                 flat_view_scroll_x = flat_view_target_x
             end
 
+            -- Pre-queue image loads outward from p so nearest covers load first
+            local function queue_cover(i)
+                if i < visible_start or i > visible_end then return end
+                local file = def[i]
+                if file and file.icon_path and FileLoad[file] == nil then
+                    FileLoad[file] = true
+                    Threads.addTask(file, {Type="ImageLoad", Path=file.icon_path, Table=file, Index="ricon"})
+                end
+            end
+            queue_cover(p)
+            for offset = 1, render_distance do
+                queue_cover(p + offset)
+                queue_cover(p - offset)
+            end
+
             -- Draw covers in visible range
             for l = visible_start, visible_end do
                 local file = def[l]
-                
-                -- Ensure image is loaded
+
+                -- Ensure image is loaded (no-op if already queued above)
                 if FileLoad[file] == nil then
                     FileLoad[file] = true
                     Threads.addTask(file, {
@@ -13546,6 +13565,23 @@ function drawCategory (def)
             base_y = fv_left_margin
             base_y_left = 0
             cover_widths_x_bonus = 0
+
+            -- Pre-queue image loads outward from p so nearest covers load first
+            local ns_total = #def
+            local function ns_queue_cover(i)
+                if i < 1 or i > ns_total then return end
+                local file = def[i]
+                if file and file.icon_path and FileLoad[file] == nil and
+                   (i > p - render_distance and i < p + render_distance + 2) then
+                    FileLoad[file] = true
+                    Threads.addTask(file, {Type="ImageLoad", Path=file.icon_path, Table=file, Index="ricon"})
+                end
+            end
+            ns_queue_cover(p)
+            for offset = 1, render_distance do
+                ns_queue_cover(p + offset)
+                ns_queue_cover(p - offset)
+            end
 
             for l, file in pairs((def)) do
                 if (l >= master_index) then

--- a/src/translations/CN_S.lua
+++ b/src/translations/CN_S.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "显示游戏核心菜单：",
 ["Global_core_settings"] = "全局核心设置",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "平台：",
 ["Emulator_core"] = "模拟器核心",
 ["Core_colon"] = "核心：",

--- a/src/translations/CN_T.lua
+++ b/src/translations/CN_T.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "顯示遊戲核心選單：",
 ["Global_core_settings"] = "全域核心設定",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "平台：",
 ["Emulator_core"] = "模擬器核心",
 ["Core_colon"] = "核心：",

--- a/src/translations/DA.lua
+++ b/src/translations/DA.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Vis spilkernemenu:",
 ["Global_core_settings"] = "Globale kerneindstillinger",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulatorkerne",
 ["Core_colon"] = "Kerne:",

--- a/src/translations/DE.lua
+++ b/src/translations/DE.lua
@@ -318,6 +318,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Spielkern-Menü anzeigen:",
 ["Global_core_settings"] = "Globale Kerneinstellungen",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plattform:",
 ["Emulator_core"] = "Emulator-Kern",
 ["Core_colon"] = "Kern:",

--- a/src/translations/EN.lua
+++ b/src/translations/EN.lua
@@ -319,6 +319,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Show game core menu:",
 ["Global_core_settings"] = "Global core settings",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulator core",
 ["Core_colon"] = "Core:",

--- a/src/translations/EN_USA.lua
+++ b/src/translations/EN_USA.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Show game core menu:",
 ["Global_core_settings"] = "Global core settings",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulator core",
 ["Core_colon"] = "Core:",

--- a/src/translations/FI.lua
+++ b/src/translations/FI.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Näytä peliydinvalikko:",
 ["Global_core_settings"] = "Globaalit ydinasetukset",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Alusta:",
 ["Emulator_core"] = "Emulaattorin ydin",
 ["Core_colon"] = "Ydin:",

--- a/src/translations/FR.lua
+++ b/src/translations/FR.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Afficher le menu des cœurs de jeu :",
 ["Global_core_settings"] = "Paramètres globaux des cœurs",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plateforme :",
 ["Emulator_core"] = "Cœur de l'émulateur",
 ["Core_colon"] = "Cœur :",

--- a/src/translations/HU.lua
+++ b/src/translations/HU.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Játékmag menü megjelenítése:",
 ["Global_core_settings"] = "Globális magbeállítások",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulátormag",
 ["Core_colon"] = "Mag:",

--- a/src/translations/IT.lua
+++ b/src/translations/IT.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Mostra menu core gioco:",
 ["Global_core_settings"] = "Impostazioni globali dei core",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Piattaforma:",
 ["Emulator_core"] = "Core dell'emulatore",
 ["Core_colon"] = "Core:",

--- a/src/translations/JA.lua
+++ b/src/translations/JA.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "ゲームコアメニューを表示：",
 ["Global_core_settings"] = "グローバルコア設定",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "プラットフォーム：",
 ["Emulator_core"] = "エミュレーターコア",
 ["Core_colon"] = "コア：",

--- a/src/translations/JA_ryu.lua
+++ b/src/translations/JA_ryu.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "ゲームコアメニュー表示：",
 ["Global_core_settings"] = "グローバルコア設定",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "プラットフォーム：",
 ["Emulator_core"] = "エミュレーターコア",
 ["Core_colon"] = "コア：",

--- a/src/translations/KO.lua
+++ b/src/translations/KO.lua
@@ -318,6 +318,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "게임 코어 메뉴 표시:",
 ["Global_core_settings"] = "전역 코어 설정",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "플랫폼:",
 ["Emulator_core"] = "에뮬레이터 코어",
 ["Core_colon"] = "코어:",

--- a/src/translations/NL.lua
+++ b/src/translations/NL.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Spelcoremenu tonen:",
 ["Global_core_settings"] = "Globale core-instellingen",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emulatorcore",
 ["Core_colon"] = "Core:",

--- a/src/translations/NO.lua
+++ b/src/translations/NO.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Vis spillkjernemeny:",
 ["Global_core_settings"] = "Globale kjerneinnstillinger",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plattform:",
 ["Emulator_core"] = "Emulatorkjerne",
 ["Core_colon"] = "Kjerne:",

--- a/src/translations/PL.lua
+++ b/src/translations/PL.lua
@@ -319,6 +319,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Pokaż menu rdzeni gier:",
 ["Global_core_settings"] = "Globalne ustawienia rdzeni",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platforma:",
 ["Emulator_core"] = "Rdzeń emulatora",
 ["Core_colon"] = "Rdzeń:",

--- a/src/translations/PT.lua
+++ b/src/translations/PT.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Mostrar menu de núcleos dos jogos:",
 ["Global_core_settings"] = "Definições globais de núcleos",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plataforma:",
 ["Emulator_core"] = "Núcleo do emulador",
 ["Core_colon"] = "Núcleo:",

--- a/src/translations/PT_BR.lua
+++ b/src/translations/PT_BR.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Mostrar menu de núcleos dos jogos:",
 ["Global_core_settings"] = "Configurações globais de núcleos",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plataforma:",
 ["Emulator_core"] = "Núcleo do emulador",
 ["Core_colon"] = "Núcleo:",

--- a/src/translations/RU.lua
+++ b/src/translations/RU.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Показывать меню игровых ядер:",
 ["Global_core_settings"] = "Глобальные настройки ядер",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Платформа:",
 ["Emulator_core"] = "Ядро эмулятора",
 ["Core_colon"] = "Ядро:",

--- a/src/translations/SP.lua
+++ b/src/translations/SP.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Mostrar menú de núcleos de juegos:",
 ["Global_core_settings"] = "Configuración global de núcleos",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plataforma:",
 ["Emulator_core"] = "Núcleo del emulador",
 ["Core_colon"] = "Núcleo:",

--- a/src/translations/SW.lua
+++ b/src/translations/SW.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Visa spelkärnmeny:",
 ["Global_core_settings"] = "Globala kärninställningar",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Plattform:",
 ["Emulator_core"] = "Emulatorkärna",
 ["Core_colon"] = "Kärna:",

--- a/src/translations/TR.lua
+++ b/src/translations/TR.lua
@@ -317,6 +317,7 @@ return {
 -- Emulator core strings
 ["Show_game_core_menu_colon"] = "Oyun çekirdeği menüsünü göster:",
 ["Global_core_settings"] = "Genel çekirdek ayarları",
+["Resume_position_colon"] = "Resume position:",
 ["Platform_colon"] = "Platform:",
 ["Emulator_core"] = "Emülatör çekirdeği",
 ["Core_colon"] = "Çekirdek:",


### PR DESCRIPTION
## Summary

- Adds a **Resume position** toggle in Other Settings (off by default)
- When enabled, saves the current category and scroll position on exit and restores it on next launch — giving the feel of resuming from a suspended state
- Invalid/deleted collections and search results are handled gracefully (falls back to the configured startup category)
- On restore, synchronously preloads the 11 covers centred on the saved position (±5) so the view is fully populated on the first frame with no pop-in
- Cover loading in both render paths (smooth and non-smooth) now queues outward from the current position so nearest covers always load first

Generated with Claude Code